### PR TITLE
[fix] 쿼리 수정

### DIFF
--- a/domain/search-domain-rdb/src/main/java/woowa/team4/bff/search/domain/RestaurantSearchResult.java
+++ b/domain/search-domain-rdb/src/main/java/woowa/team4/bff/search/domain/RestaurantSearchResult.java
@@ -8,17 +8,17 @@ public class RestaurantSearchResult {
 
     private UUID restaurantUuid;
     private String restaurantName;
-    private Integer minimumOrderPrice;
+    private Integer minimumOrderAmount;
     // ToDo: ReviewStatus Domain 기능 완성 후 추가
 //    private Double rating;
 //    private Integer reviewCount;
-    private String menuName;
+    private String menuNames;
 
-    public RestaurantSearchResult(UUID restaurantUuid, String restaurantName, Integer minimumOrderPrice,
-                                  String menuName) {
+    public RestaurantSearchResult(UUID restaurantUuid, String restaurantName, Integer minimumOrderAmount,
+                                  String menuNames) {
         this.restaurantUuid = restaurantUuid;
         this.restaurantName = restaurantName;
-        this.minimumOrderPrice = minimumOrderPrice;
-        this.menuName = menuName;
+        this.minimumOrderAmount = minimumOrderAmount;
+        this.menuNames = menuNames;
     }
 }

--- a/domain/search-domain-rdb/src/main/java/woowa/team4/bff/search/repository/RestaurantEntityRepository.java
+++ b/domain/search-domain-rdb/src/main/java/woowa/team4/bff/search/repository/RestaurantEntityRepository.java
@@ -9,10 +9,13 @@ import woowa.team4.bff.search.domain.RestaurantSearchResult;
 
 public interface RestaurantEntityRepository extends JpaRepository<RestaurantEntity, Long> {
     // ToDo: Restauarnt, Menu, ReviewStatus 관련 module 완성시 사용
-    @Query("SELECT new woowa.team4.bff.search.domain.RestaurantSearchResult(r.uuid, r.name, r.minimumOrderAmount, m.name) " +
+    @Query("SELECT new woowa.team4.bff.search.domain.RestaurantSearchResult(r.uuid, r.name, r.minimumOrderAmount, " +
+            "CAST((SELECT COALESCE(GROUP_CONCAT(m.name), '') " +
+            "FROM MenuEntity m " +
+            "JOIN MenuCategoryEntity mc ON m.menuCategoryId = mc.id " +
+            "WHERE mc.restaurantId = r.id) AS string)) " +
             "FROM RestaurantEntity r " +
-            "LEFT JOIN MenuCategoryEntity mc ON r.id = mc.restaurantId " +
-            "LEFT JOIN MenuEntity m ON mc.id = m.menuCategoryId " +
-            "WHERE r.id IN :restaurantIds and r.deliveryLocation = :deliveryLocation")
+            "WHERE r.id IN :restaurantIds AND r.deliveryLocation = :deliveryLocation " +
+            "GROUP BY r.id")
     List<RestaurantSearchResult> findRestaurantSearchResults(@Param("restaurantIds") List<Long> restaurantIds, @Param("deliveryLocation") String deliveryLocation);
 }


### PR DESCRIPTION
- 한 식당 메뉴가 여러개 여도 식당이 하나만 출력되게 수정

## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호
- #75 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 테크 스펙 : (테크 스펙 url)

- 목록 조회 쿼리 결과가 기존 식당에 메뉴가 2개 이상일 경우 식당이 메뉴 수만큼 조회되는 현상 발생
- 메뉴가 복수여도 식당이 목록에서 한번만 조회 되도록 수정

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

---
### RCA 룰
| 코드 리뷰 멘토가 PR작성자에게 어떤 의도로 전달 되길 바라는지 알파벳으로 표현해주세요!
- r(request change): 꼭 반영
- c(comment): 왠만하면 반영
- a(approve): 반영해도 좋고 넘어가도 좋은 의견
