### PR TITLE
[fix] 동일 키워드와 동일 id가 오면 동일 광고가 응답되게 수정

### DIFF
--- a/service/advertisement-service/src/main/java/woowa/team4/bff/advertisementservice/AdvertisementController.java
+++ b/service/advertisement-service/src/main/java/woowa/team4/bff/advertisementservice/AdvertisementController.java
@@ -3,6 +3,8 @@ package woowa.team4.bff.advertisementservice;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,6 +20,8 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdvertisementController {
 
     private final Random random = new Random();
+    private final ConcurrentHashMap<String, ConcurrentHashMap<Long, AdvertisementResponse>> advertisementCache = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, AtomicInteger> keywordRanks = new ConcurrentHashMap<>();
 
     @PostMapping
     public List<AdvertisementResponse> getAdvertisements(
@@ -31,9 +35,18 @@ public class AdvertisementController {
             throw new RuntimeException(e);
         }
 
+        String keyword = request.getKeyword();
+        ConcurrentHashMap<Long, AdvertisementResponse> keywordCache = advertisementCache.computeIfAbsent(keyword, k -> new ConcurrentHashMap<>());
+        AtomicInteger rank = keywordRanks.computeIfAbsent(keyword, k -> new AtomicInteger(0));
+
         for (Long id : request.getIds()) {
-            int rank = 0;
-            responses.add(new AdvertisementResponse(id, ++rank, random.nextBoolean()));
+            AdvertisementResponse response = keywordCache.computeIfAbsent(id,
+                    key -> {
+                        boolean hasAd = random.nextBoolean();
+                        int adRank = hasAd ? rank.incrementAndGet() : Integer.MAX_VALUE;
+                        return new AdvertisementResponse(key, adRank, hasAd);
+                    });
+            responses.add(response);
         }
 
         return responses;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

- #129 

## 📝 작업 내용

- 같은 키워드 & 같은 가게 Id 요청시 광고 서버가 같은 광고 응답을 주게 수정

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 테크 스펙 : (테크 스펙 url)

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

---
### RCA 룰
| 코드 리뷰 멘토가 PR작성자에게 어떤 의도로 전달 되길 바라는지 알파벳으로 표현해주세요!
- r(request change): 꼭 반영
- c(comment): 왠만하면 반영
- a(approve): 반영해도 좋고 넘어가도 좋은 의견
