### PR TITLE
[refactor] Elasticsearch에서 검색할 때 restaurantId 필드만 조회하도록 변경

### DIFF
--- a/core-web/src/main/java/woowa/team4/bff/common/exception/GeneralExceptionHandler.java
+++ b/core-web/src/main/java/woowa/team4/bff/common/exception/GeneralExceptionHandler.java
@@ -1,5 +1,6 @@
 package woowa.team4.bff.common.exception;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -17,6 +18,7 @@ import woowa.team4.bff.common.utils.ApiUtils.ApiResult;
 /**
  * 전역 예외 처리를 위한 클래스이다. 이 클래스는 애플리케이션에서 발생하는 다양한 예외를 잡아 적절한 HTTP 응답으로 변환한다.
  */
+@Slf4j
 @ControllerAdvice
 public class GeneralExceptionHandler {
 
@@ -65,6 +67,7 @@ public class GeneralExceptionHandler {
     @ExceptionHandler({IllegalArgumentException.class, IllegalStateException.class,
             MethodArgumentNotValidException.class})
     public ResponseEntity<?> handleBadRequestException(Exception e) {
+        log.error("잘못된 요청", e);
         if (e instanceof MethodArgumentNotValidException) {
             return newResponse(
                     ((MethodArgumentNotValidException) e).getBindingResult().getAllErrors().get(0)
@@ -115,6 +118,7 @@ public class GeneralExceptionHandler {
      */
     @ExceptionHandler({Exception.class, RuntimeException.class})
     public ResponseEntity<?> handleException(Exception e) {
+        log.error("서버 오류", e);
         return newResponse(e, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }

--- a/domain/search-domain-es/src/main/java/woowa/team4/bff/search/service/SearchElasticsearchService.java
+++ b/domain/search-domain-es/src/main/java/woowa/team4/bff/search/service/SearchElasticsearchService.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.client.elc.NativeQuery;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.query.FetchSourceFilter;
 import org.springframework.stereotype.Service;
 import woowa.team4.bff.interfaces.SearchService;
 import woowa.team4.bff.search.document.RestaurantMenusDocument;
@@ -39,6 +40,7 @@ public class SearchElasticsearchService implements SearchService {
                                 .query(nestedQuery -> nestedQuery.match(match -> match.field("menus.menuName").query(keyword))))
                         )))
                 .withSort(sort -> sort.score(score -> score.order(SortOrder.Desc)))
+                .withSourceFilter(FetchSourceFilter.of(new String[]{"restaurantId"}, null))
                 .withPageable(Pageable.ofSize(DEFAULT_MAX_SIZE))
                 .build();
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#140 

## 📝 작업 내용

- `NativeQuery`를 빌드할 때 `withSourceFilter()` 옵션을 사용해 가게 ID(`restaurantId`)만 조회하도록 수정(리소스 절약 기대)
- 테크 스펙 : (테크 스펙 url)

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

---
### RCA 룰
| 코드 리뷰 멘토가 PR작성자에게 어떤 의도로 전달 되길 바라는지 알파벳으로 표현해주세요!
- r(request change): 꼭 반영
- c(comment): 왠만하면 반영
- a(approve): 반영해도 좋고 넘어가도 좋은 의견
